### PR TITLE
fix file extname for Gulp 3

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ const lodash = require('lodash');
 const through2 = require('through2');
 const gutil = require('gulp-util');
 const notSupportedFile = require('gulp-not-supported-file');
+const rewrite = require('rewrite-ext');
 
 // data
 const pkg = require('./package.json');
@@ -183,7 +184,11 @@ function gulpEjsMonster (opts = {}) {
 
 				// change file data
 				file.contents = Buffer.from(markup);
-				file.extname = options.extname;
+				if (file.extname) {
+					file.extname = options.extname;
+				} else {
+					file.path = rewrite(file.path, options.extname);
+				}
 
 				// all done - go out
 				return cb(null, file);

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "gulp-util": "^3.0.8",
     "json-lint": "^0.1.0",
     "lodash": "^4.5.0",
+    "rewrite-ext": "^1.0.0",
     "through2": "^2.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Небольшое исправление для gulp 3 версии, так как на выходе получали .ejs файлы.